### PR TITLE
Avoid unhandled rejection assertion.

### DIFF
--- a/tests/integration/components/my-component-test.js
+++ b/tests/integration/components/my-component-test.js
@@ -25,7 +25,11 @@ test('success', function(assert) {
 test('error', function(assert) {
   assert.expect(1);
 
-  this.set('promise', RSVP.reject('bar'));
+  let promise = RSVP.reject('bar')
+  // avoid unhandled rejection assertion
+  promise.catch(() => {});
+
+  this.set('promise', promise);
 
   this.render(hbs`{{my-component promise=promise}}`);
 


### PR DESCRIPTION
Calling `.catch` on a rejected promise returns a new promise, but it also marks the "parent" promise as a "handled rejection" (which avoids the unhandled rejection assertion).